### PR TITLE
Some ideas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 FROM mono:latest
 
+# user for execution
+ARG UID=10000
+ARG GID=10000
+RUN RUN groupadd -r -g $GID procon && \
+    useradd -r -g procon -u $UID procon
+
+
 RUN mkdir -p /procon && \
 	apt-get update && \
 	apt-get install unzip wget -y && \
@@ -13,5 +20,7 @@ VOLUME /procon/Configs ./Configs
 VOLUME /procon/Plugins ./Plugins
 
 EXPOSE 27260
+
+USER procon:procon
 
 CMD [ "mono",  "./PRoCon.Console.exe" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,7 @@ RUN mkdir -p /procon && \
 	
 WORKDIR /procon
 
-VOLUME /procon/Configs ./Configs
-VOLUME /procon/Plugins ./Plugins
+VOLUME ["/procon/Configs", "/opt/procon/Plugins"]
 
 USER procon:procon
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /procon && \
 	wget -O /tmp/procon.zip https://api.myrcon.net/procon/download?p=docker && \
 	unzip -x /tmp/procon.zip -d /procon/ && \
     chown procon:procon -R /procon/ && \
-    rm -f /tmp/procon.zip
+    rm -r /tmp/procon.zip /procon/Plugins /procon/Configs
 	
 WORKDIR /procon
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:latest
 # user for execution
 ARG UID=10000
 ARG GID=10000
-RUN RUN groupadd -r -g $GID procon && \
+RUN groupadd -r -g $GID procon && \
     useradd -r -g procon -u $UID procon
 
 
@@ -12,8 +12,8 @@ RUN mkdir -p /procon && \
 	apt-get install unzip wget -y && \
 	wget -O /tmp/procon.zip https://api.myrcon.net/procon/download?p=docker && \
 	unzip -x /tmp/procon.zip -d /procon/ && \
-    chown procon:procon -R /procon && \
-    rm -r /procon/Configs /procon/Plugins /tmp/procon.zip
+    chown procon:procon -R /procon/ && \
+    rm -f /tmp/procon.zip
 	
 WORKDIR /procon
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,6 @@ WORKDIR /procon
 VOLUME /procon/Configs ./Configs
 VOLUME /procon/Plugins ./Plugins
 
-EXPOSE 27260
-
 USER procon:procon
 
-CMD [ "mono",  "./PRoCon.Console.exe" ]
+ENTRYPOINT [ "mono",  "PRoCon.Console.exe" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN mkdir -p /procon && \
 	apt-get install unzip wget -y && \
 	wget -O /tmp/procon.zip https://api.myrcon.net/procon/download?p=docker && \
 	unzip -x /tmp/procon.zip -d /procon/ && \
-    rm -f /tmp/procon.zip
+    chown procon:procon -R /procon && \
+    rm -r /procon/Configs /procon/Plugins /tmp/procon.zip
 	
 WORKDIR /procon
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,13 +13,9 @@ services:
       - type: bind
         source: ./Config1
         target: /procon/Configs
-        volume:
-          nocopy: true
       - type: bind
         source: ./Plugins
         target: /procon/Plugins
-        volume:
-          nocopy: true
       # - type: bind
       #   source: ./Logs
       #   target: /procon/Logs
@@ -39,13 +35,9 @@ services:
     #     - type: bind
     #       source: ./Config2
     #       target: /procon/Configs
-    #       volume:
-    #         nocopy: true
     #     - type: bind
     #       source: ./Plugins
     #       target: /procon/Plugins
-    #       volume:
-    #         nocopy: true
     #     # - type: bind
     #     #   source: ./Logs
     #     #   target: /procon/Logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - 27260:27260
     volumes:
       - type: bind
-        source: ./Config1
+        source: ./Configs1
         target: /procon/Configs
       - type: bind
         source: ./Plugins
@@ -21,24 +21,19 @@ services:
       #   target: /procon/Logs
     tty: true
 
-    # create a service for each BF server with its own Config folder
-    # procon2:
-    #   container_name: procon2
-    #   build:
-    #     context: .
-    #   image: procon/procon:1.0
-    #   restart: unless-stopped
-    #   ports:
-    #     # format: localPort:containerPort
-    #     - 27261:27260
-    #   volumes:
-    #     - type: bind
-    #       source: ./Config2
-    #       target: /procon/Configs
-    #     - type: bind
-    #       source: ./Plugins
-    #       target: /procon/Plugins
-    #     # - type: bind
-    #     #   source: ./Logs
-    #     #   target: /procon/Logs
-    #   tty: true
+#  procon2:
+#    container_name: procon2
+#    build:
+#      context: .
+#    image: procon/procon:1.0
+#    restart: unless-stopped
+#    ports:
+#      - 27261:27260
+#    volumes:
+#      - type: bind
+#        source: ./Configs2
+#        target: /procon/Configs
+#      - type: bind
+#        source: ./Plugins
+#        target: /procon/Plugins
+#    tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '2.4'
+services:
+  procon1:
+    container_name: procon1
+    build:
+      context: .
+    image: procon/procon:1.0
+    restart: unless-stopped
+    ports:
+      # format: localPort:containerPort
+      - 27260:27260
+    volumes:
+      - type: bind
+        source: ./Config1
+        target: /procon/Configs
+      - type: bind
+        source: ./Plugins
+        target: /procon/Plugins
+      # - type: bind
+      #   source: ./Logs
+      #   target: /procon/Logs
+    tty: true
+
+    # create a service for each BF server with its own Config folder
+    # procon2:
+    #   container_name: procon2
+    #   build:
+    #     context: .
+    #   image: procon/procon:1.0
+    #   restart: unless-stopped
+    #   ports:
+    #     # format: localPort:containerPort
+    #     - 27261:27260
+    #   volumes:
+    #     - type: bind
+    #       source: ./Config2
+    #       target: /procon/Configs
+    #     - type: bind
+    #       source: ./Plugins
+    #       target: /procon/Plugins
+    #     # - type: bind
+    #     #   source: ./Logs
+    #     #   target: /procon/Logs
+    #   tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,13 @@ services:
       - type: bind
         source: ./Config1
         target: /procon/Configs
+        volume:
+          nocopy: true
       - type: bind
         source: ./Plugins
         target: /procon/Plugins
+        volume:
+          nocopy: true
       # - type: bind
       #   source: ./Logs
       #   target: /procon/Logs
@@ -35,9 +39,13 @@ services:
     #     - type: bind
     #       source: ./Config2
     #       target: /procon/Configs
+    #       volume:
+    #         nocopy: true
     #     - type: bind
     #       source: ./Plugins
     #       target: /procon/Plugins
+    #       volume:
+    #         nocopy: true
     #     # - type: bind
     #     #   source: ./Logs
     #     #   target: /procon/Logs

--- a/fixPermissions.sh
+++ b/fixPermissions.sh
@@ -1,0 +1,1 @@
+sudo chown 10000:10000 -R Config* Plugin*


### PR DESCRIPTION
So the folder structure is:

- Configs1
- Configs2
- ....
- Plugins

The plugin folder would be shared between all docker containers (Not sure if that will work, because all containers would probably try to compile the plugins at the same time) Maybe it works?
Otherwise you would need a own plugin folder for each instance of procon...

Create and build all containers with
- sudo docker-compose up -d
- Each procon needs its own section in docker-compose file.(I added a 2nd server as an example)

oh... the build section in docker-compose tells docker compose to build the container each time. That will not happen, because the image would have the name procon/procon:1.0, but the build section is actually only needed for the 1st container.

To rebuilt a container do:

- sudo docker-compose down --rmi all
- sudo docker-compose up -d
